### PR TITLE
zh_CN: Switch to A4 paper

### DIFF
--- a/zh_CN/lang.mk
+++ b/zh_CN/lang.mk
@@ -62,5 +62,6 @@ $(FONTS_XSL): zh_CN/zh_CN-fonts.xsl
 
 zh_CN/book/$(PDF_XSL): $(LFS_EN)/$(PDF_XSL) $(FONTS_XSL) $(THIS)
 	mkdir -pv $(@D)
-	sed '/<\/xsl:stylesheet>/i <xsl:include href="pdf/zh_CN-fonts.xsl"/>' \
+	sed -e '/<\/xsl:stylesheet>/i <xsl:include href="pdf/zh_CN-fonts.xsl"/>' \
+	    -e 's/USletter/A4/' \
 		< $< > $@


### PR DESCRIPTION
A4 is more common than US Letter in China ~~, and it may also resolve the <screen> overflow caused by a larger font.~~